### PR TITLE
update syntax of deno.json

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -6,11 +6,9 @@
     ]
   },
   "fmt": {
-    "options": {
-      "useTabs": false,
-      "lineWidth": 120,
-      "indentWidth": 2
-    }
+    "useTabs": false,
+    "lineWidth": 120,
+    "indentWidth": 2
   },
   "lint": {
     "rules": {

--- a/tools/init/deno.json
+++ b/tools/init/deno.json
@@ -6,11 +6,9 @@
     ]
   },
   "fmt": {
-    "options": {
-      "useTabs": false,
-      "lineWidth": 120,
-      "indentWidth": 2
-    }
+    "useTabs": false,
+    "lineWidth": 120,
+    "indentWidth": 2
   },
   "lint": {
     "rules": {


### PR DESCRIPTION
[Syntax of `deno.json` has been simplified at version 1.34](https://github.com/denoland/deno/pull/17799), this pr update syntax to avoid warning of `fmt`