### PR TITLE
Add SDL_WaitEvent and SDL_WaitEventTimeout

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -32,6 +32,16 @@
       "attachSimplePort": 9229
     },
     {
+      "name": "Debug Hello World Async",
+      "type": "node",
+      "request": "launch",
+      "cwd": "${workspaceFolder}",
+      "env": { "DENO_FLAGS": "--inspect-brk" },
+      "runtimeExecutable": "deno",
+      "runtimeArgs": ["task", "run:hello-world-async"],
+      "attachSimplePort": 9229
+    },
+    {
       "name": "Debug Renderer",
       "type": "node",
       "request": "launch",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -92,6 +92,24 @@
       ]
     },
     {
+      "label": "Run Hello World Async",
+      "group": {
+        "kind": "none",
+        "isDefault": true
+      },
+      "type": "deno",
+      "command": "task",
+      "args": [
+        "run:hello-world-async"
+      ],
+      "options": {
+        "cwd": "${workspaceFolder}"
+      },
+      "problemMatcher": [
+        "$deno"
+      ]
+    },
+    {
       "label": "Run Renderer",
       "group": {
         "kind": "none",

--- a/deno.json
+++ b/deno.json
@@ -30,6 +30,7 @@
     "run:init": "deno run --allow-net --allow-read=. --allow-write=. ./init.ts ./tmp/init",
     "run:doom-fire": "cd ./examples/doom-fire && SDL_TS_ENV_DIR=$INIT_CWD deno run --unstable --allow-env --allow-ffi --allow-read=../.. $DENO_FLAGS ./main.ts",
     "run:hello-world": "cd ./examples/hello-world && SDL_TS_ENV_DIR=$INIT_CWD deno run --unstable --allow-env --allow-ffi --allow-read=../.. $DENO_FLAGS ./main.ts",
+    "run:hello-world-async": "cd ./examples/hello-world-async && SDL_TS_ENV_DIR=$INIT_CWD deno run --unstable --allow-env --allow-ffi --allow-read=../.. $DENO_FLAGS ./main.ts",
     "run:renderer": "cd ./examples/renderer && SDL_TS_ENV_DIR=$INIT_CWD deno run --unstable --allow-env --allow-ffi --allow-read=../.. $DENO_FLAGS ./main.ts",
     "run:same-game": "cd ./examples/same-game && SDL_TS_ENV_DIR=$INIT_CWD deno run --unstable --allow-env --allow-ffi --allow-read=../.. $DENO_FLAGS ./main.ts",
     "test": "deno test --unstable --allow-ffi"

--- a/examples/hello-world-async/main.ts
+++ b/examples/hello-world-async/main.ts
@@ -1,0 +1,80 @@
+import { Events, SDL } from "SDL_ts";
+import { SDL_FUNCTIONS } from "./sdlConfig.ts";
+
+SDL.Init(SDL.InitFlags.VIDEO, { functions: SDL_FUNCTIONS });
+
+console.info("SDL Initialized.");
+
+const window = SDL.CreateWindow(
+  "Hello World!",
+  SDL.WindowPos.CENTERED,
+  SDL.WindowPos.CENTERED,
+  1024,
+  768,
+  SDL.WindowFlags.SHOWN | SDL.WindowFlags.RESIZABLE,
+);
+
+if (window == null) {
+  console.error(`Failed to create window: ${SDL.GetError()}`);
+  Deno.exit(1);
+}
+
+let surface = SDL.GetWindowSurface(window);
+
+if (surface == null) {
+  console.error(`Failed to get window surface: ${SDL.GetError()}`);
+  Deno.exit(1);
+}
+
+SDL.FillRect(
+  surface,
+  null,
+  SDL.MapRGB(surface.format, 0x64, 0x95, 0xED),
+);
+SDL.UpdateWindowSurface(window);
+
+for await (const event of Events.asyncIterator()) {
+  if (event.type === SDL.EventType.QUIT) {
+    console.info("Done.");
+    break;
+  } else if (event.type === SDL.EventType.WINDOWEVENT) {
+    if (event.window.event === SDL.WindowEventID.SHOWN) {
+      console.info(`Window ${event.window.windowID} shown.`);
+    } else if (event.window.event === SDL.WindowEventID.MINIMIZED) {
+      console.info(`Window ${event.window.windowID} minimized.`);
+    } else if (event.window.event === SDL.WindowEventID.RESTORED) {
+      console.info(`Window ${event.window.windowID} restored.`);
+    } else if (event.window.event === SDL.WindowEventID.RESIZED) {
+      console.info(`Window ${event.window.windowID} resized: ${event.window.data1} ${event.window.data2}`);
+      surface = SDL.GetWindowSurface(window);
+
+      if (surface == null) {
+        console.error(`Failed to get window surface: ${SDL.GetError()}`);
+        Deno.exit(1);
+      }
+
+      SDL.FillRect(
+        surface,
+        null,
+        SDL.MapRGB(surface.format, 0x64, 0x95, 0xED),
+      );
+      SDL.UpdateWindowSurface(window);
+    }
+  } else if (event.type === SDL.EventType.KEYDOWN) {
+    console.info(`KeyDown: ${event.key.keysym.scancode} "${SDL.GetScancodeName(event.key.keysym.scancode)}"`);
+  } else if (event.type === SDL.EventType.KEYUP) {
+    console.info(`KeyUp: ${event.key.keysym.scancode} "${SDL.GetScancodeName(event.key.keysym.scancode)}"`);
+  } else if (event.type === SDL.EventType.MOUSEMOTION) {
+    console.info(`MouseMotion: (${event.mousebutton.x}, ${event.mousebutton.y})`);
+  } else if (event.type === SDL.EventType.MOUSEBUTTONDOWN) {
+    console.info(`MouseButtonDown: ${event.mousebutton.button} (${event.mousebutton.x}, ${event.mousebutton.y})`);
+  } else if (event.type === SDL.EventType.MOUSEBUTTONUP) {
+    console.info(`MouseButtonUp: ${event.mousebutton.button} (${event.mousebutton.x}, ${event.mousebutton.y})`);
+  } else if (event.type === SDL.EventType.MOUSEWHEEL) {
+    console.info(`MouseWheel: ${event.mousewheel.direction} (${event.mousebutton.x}, ${event.mousebutton.y})`);
+  }
+}
+
+SDL.DestroyWindow(window);
+SDL.Quit();
+console.info("SDL Shutdown.");

--- a/examples/hello-world-async/sdlConfig.ts
+++ b/examples/hello-world-async/sdlConfig.ts
@@ -1,0 +1,16 @@
+import { SDL } from "SDL_ts";
+
+// This file contains the list of functions that are used in the project.
+
+export const SDL_FUNCTIONS = [
+  SDL.CreateWindow,
+  SDL.DestroyWindow,
+  SDL.FillRect,
+  SDL.GetError,
+  SDL.GetWindowSurface,
+  SDL.Init,
+  SDL.MapRGB,
+  SDL.Quit,
+  SDL.UpdateWindowSurface,
+  SDL.WaitEvent,
+] as const;

--- a/mod.ts
+++ b/mod.ts
@@ -3,6 +3,7 @@ export * as IMG from "./mod.SDL_image.ts";
 export * as TTF from "./mod.SDL_ttf.ts";
 export * from "./src/boxes.ts";
 export * from "./src/error.ts";
+export * from "./src/events.ts";
 export * from "./src/memory.ts";
 export * from "./src/pointers.ts";
 export * from "./src/types.ts";

--- a/src/SDL/_symbols.ts
+++ b/src/SDL/_symbols.ts
@@ -522,4 +522,17 @@ export const symbols = {
     ],
     result: /* int */ "i32",
   },
+  SDL_WaitEvent: {
+    parameters: [
+      /* SDL_Event* event */ "pointer",
+    ],
+    result: /* int */ "i32",
+  },
+  SDL_WaitEventTimeout: {
+    parameters: [
+      /* SDL_Event* event */ "pointer",
+      /* int timeout */ "i32",
+    ],
+    result: /* int */ "i32",
+  },
 } as const;

--- a/src/SDL/functions.ts
+++ b/src/SDL/functions.ts
@@ -899,3 +899,23 @@ export function UpdateWindowSurface(
   ) as i32;
 }
 UpdateWindowSurface.symbolName = "SDL_UpdateWindowSurface";
+
+export function WaitEvent(
+  event: PointerLike<Event>,
+): i32 {
+  return _library.symbols.SDL_WaitEvent(
+    Platform.toPlatformPointer(Pointer.of(event)),
+  ) as i32;
+}
+WaitEvent.symbolName = "SDL_WaitEvent";
+
+export function WaitEventTimeout(
+  event: PointerLike<Event>,
+  timeout: i32,
+): i32 {
+  return _library.symbols.SDL_WaitEventTimeout(
+    Platform.toPlatformPointer(Pointer.of(event)),
+    timeout,
+  ) as i32;
+}
+WaitEventTimeout.symbolName = "SDL_WaitEventTimeout";

--- a/src/events.ts
+++ b/src/events.ts
@@ -3,29 +3,33 @@ import { GetError, WaitEvent } from "./SDL/functions.ts";
 export class Events {
   /**
    * Get a lazy stream of @see SDL.Event using SDL_WaitEvent.
-   * @returns a lazy stream of @see SDL.Event using SDL_WaitEvent
+   * @returns A lazy stream of @see SDL.Event
    * @example
    * ```ts
    * for await (const event of Events.asyncIterator()) {
-   *   console.log(event.type)
+   *   console.log(event.type);
    * }
    * ```
    */
-  public static asyncIterator(_event?: Event): AsyncIterator<Event, never, never> {
+  public static asyncIterator(_event?: Event): AsyncIterable<Event> {
     const event = _event ?? new Event();
     return {
-      next(): Promise<IteratorResult<Event, never>> {
-        return new Promise<IteratorResult<Event, never>>((resolve, reject) => {
-          const res = WaitEvent(event);
-          if (res == 0) {
-            reject(GetError());
-          } else {
-            resolve({
-              done: false,
-              value: event,
+      [Symbol.asyncIterator](): AsyncIterator<Event> {
+        return {
+          next(): Promise<IteratorResult<Event, never>> {
+            return new Promise<IteratorResult<Event, never>>((resolve, reject) => {
+              const result = WaitEvent(event);
+              if (result === 0) {
+                reject(GetError());
+              } else {
+                resolve({
+                  done: false,
+                  value: event,
+                });
+              }
             });
           }
-        });
+        };
       },
     };
   }

--- a/src/events.ts
+++ b/src/events.ts
@@ -1,9 +1,9 @@
-import * as SDL from "../mod.SDL.ts";
-
+import { Event } from "./SDL/events.ts";
+import { GetError, WaitEvent } from "./SDL/functions.ts";
 export class Events {
   /**
-   * Get a lazy stream of events using SDL_WaitEvent.
-   * @returns a lazy stream of events using SDL_WaitEvent
+   * Get a lazy stream of @see SDL.Event using SDL_WaitEvent.
+   * @returns a lazy stream of @see SDL.Event using SDL_WaitEvent
    * @example
    * ```ts
    * for await (const event of Events.asyncIterator()) {
@@ -11,21 +11,18 @@ export class Events {
    * }
    * ```
    */
-  public static asyncIterator(): AsyncIterator<SDL.Event, never, SDL.Event | undefined> {
-    let _event = new SDL.Event();
+  public static asyncIterator(_event?: Event): AsyncIterator<Event, never, never> {
+    const event = _event ?? new Event();
     return {
-      next(event): Promise<IteratorResult<SDL.Event, never>> {
-        if (event) {
-          _event = event;
-        }
-        return new Promise<IteratorResult<SDL.Event, never>>((resolve, reject) => {
-          const res = SDL.WaitEvent(_event);
+      next(): Promise<IteratorResult<Event, never>> {
+        return new Promise<IteratorResult<Event, never>>((resolve, reject) => {
+          const res = WaitEvent(event);
           if (res == 0) {
-            reject(SDL.GetError());
+            reject(GetError());
           } else {
             resolve({
               done: false,
-              value: _event,
+              value: event,
             });
           }
         });

--- a/src/events.ts
+++ b/src/events.ts
@@ -1,0 +1,35 @@
+import * as SDL from "../mod.SDL.ts";
+
+export class Events {
+  /**
+   * Get a lazy stream of events using SDL_WaitEvent.
+   * @returns a lazy stream of events using SDL_WaitEvent
+   * @example
+   * ```ts
+   * for await (const event of Events.asyncIterator()) {
+   *   console.log(event.type)
+   * }
+   * ```
+   */
+  public static asyncIterator(): AsyncIterator<SDL.Event, never, SDL.Event | undefined> {
+    let _event = new SDL.Event();
+    return {
+      next(event): Promise<IteratorResult<SDL.Event, never>> {
+        if (event) {
+          _event = event;
+        }
+        return new Promise<IteratorResult<SDL.Event, never>>((resolve, reject) => {
+          const res = SDL.WaitEvent(_event);
+          if (res == 0) {
+            reject(SDL.GetError());
+          } else {
+            resolve({
+              done: false,
+              value: _event,
+            });
+          }
+        });
+      },
+    };
+  }
+}

--- a/tools/codegen/SDL/functions.ts
+++ b/tools/codegen/SDL/functions.ts
@@ -1115,4 +1115,29 @@ export const functions: CodeGenFunctions = {
       type: "int",
     },
   },
+
+  SDL_WaitEvent: {
+    parameters: {
+      event: {
+        type: "SDL_Event*",
+      },
+    },
+    result: {
+      type: "int",
+    },
+  },
+
+  SDL_WaitEventTimeout: {
+    parameters: {
+      event: {
+        type: "SDL_Event*",
+      },
+      timeout: {
+        type: "int",
+      },
+    },
+    result: {
+      type: "int",
+    },
+  },
 } as const;


### PR DESCRIPTION
These two api will wait a long time until next event arrives. #7 

An async iterator using `SDL_WaitEvent` shown here:
```ts
const SDLEvents: AsyncIterator<SDL.Event, never, SDL.Event | undefined> = (() => {
  let _event = new SDL.Event();
  return {
    next(event): Promise<IteratorResult<SDL.Event, never>> {
      if (event) {
        _event = event;
      }
      return new Promise<IteratorResult<SDL.Event, never>>((resolve, reject) => {
        const res = SDL.WaitEvent(_event);
        if (res == 0) {
          reject(SDL.GetError());
        } else {
          resolve({
            done: false,
            value: _event,
          });
        }
      });
    },
  };
})();
```