### PR TITLE
Update _library.ts to support SDL2 installed by homebrew

### DIFF
--- a/src/deno/_library.ts
+++ b/src/deno/_library.ts
@@ -13,7 +13,7 @@ const UNIX_LIBRARY_PATHS: string[] = [
   "/usr/lib64",
 ];
 
-const MACOS_LIBRARY_PATHS: string[] = ["/System/Volumes/Data/opt/homebrew/lib", "/usr/local/lib"];
+const MACOS_LIBRARY_PATHS: string[] = ["/usr/local/lib", "/System/Volumes/Data/opt/homebrew/lib"];
 
 function getLibrarySuffix(): string {
   switch (Deno.build.os) {

--- a/src/deno/_library.ts
+++ b/src/deno/_library.ts
@@ -13,7 +13,7 @@ const UNIX_LIBRARY_PATHS: string[] = [
   "/usr/lib64",
 ];
 
-const MACOS_LIBRARY_PATHS: string[] = ["/System/Volumes/Data/opt/homebrew/lib"];
+const MACOS_LIBRARY_PATHS: string[] = ["/System/Volumes/Data/opt/homebrew/lib", "/usr/local/lib"];
 
 function getLibrarySuffix(): string {
   switch (Deno.build.os) {


### PR DESCRIPTION
to enable lib linking on Mac (x64), install `sdl2` using Homebrew.
```shell
brew install sdl2 sdl2_image sdl2_ttf
```

Homebrew will install into `/usr/local/lib` by default.