### PR TITLE
Add support for sdl installed from homebrew in linux

### DIFF
--- a/src/deno/_library.ts
+++ b/src/deno/_library.ts
@@ -8,7 +8,11 @@ const IS_MAC = Deno.build.os === "darwin";
 
 const WINDOWS_LIBRARY_PATHS: string[] = [];
 
-const UNIX_LIBRARY_PATHS: string[] = ["/usr/local/lib", "/usr/lib64"];
+const UNIX_LIBRARY_PATHS: string[] = [
+  "/usr/local/lib",
+  "/usr/lib64",
+  "/home/linuxbrew/.linuxbrew/lib"
+];
 
 const MACOS_LIBRARY_PATHS: string[] = [
   "/usr/local/lib",


### PR DESCRIPTION
This PR adds support to sdl installed from homebrew in linux.

From homebrew docs (https://docs.brew.sh/Homebrew-on-Linux), the default installation is done to the path `/home/linuxbrew/.linuxbrew`, and similar to what we have on macos, we have a `lib` folder containing the lib files.

Providing the `libraryPath` option to `SDL.Init` does not seems to works because it appends `/linux/x64` to the lib path.

All examples still works.