### PR TITLE
Add support for `SDL_RenderSetLogicalSize`

### DIFF
--- a/examples/renderer/main.ts
+++ b/examples/renderer/main.ts
@@ -15,7 +15,7 @@ function main(): number {
   SDL.CreateWindowAndRenderer(
     WINDOW_WIDTH,
     WINDOW_HEIGHT,
-    SDL.WindowFlags.SHOWN,
+    SDL.WindowFlags.SHOWN | SDL.WindowFlags.RESIZABLE,
     windowBox,
     rendererBox
   );
@@ -26,6 +26,8 @@ function main(): number {
   const renderer = rendererBox.unboxNotNull(
     () => `Failed to create renderer: ${SDL.GetError()}`
   );
+
+  SDL.RenderSetLogicalSize(renderer, WINDOW_WIDTH, WINDOW_HEIGHT)
 
   const rendererInfo = new SDL.RendererInfo();
   if (SDL.GetRendererInfo(renderer, rendererInfo) != 0) {

--- a/examples/renderer/sdlConfig.ts
+++ b/examples/renderer/sdlConfig.ts
@@ -25,6 +25,7 @@ export const SDL_FUNCTIONS = [
   SDL.RenderFillRect,
   SDL.RenderFlush,
   SDL.RenderPresent,
+  SDL.RenderSetLogicalSize,
   SDL.RWFromFile,
   SDL.SetRenderDrawColor,
 ] as const;

--- a/src/SDL/_symbols.ts
+++ b/src/SDL/_symbols.ts
@@ -710,6 +710,14 @@ export const symbols = {
     ],
     result: /* SDL_Window* */ "pointer",
   },
+  SDL_RenderSetLogicalSize: {
+    parameters: [
+      /* SDL_Renderer* renderer */ "pointer",
+      /* int width */ "i32",
+      /* int height */ "i32",
+    ],
+    result: /* int */ "i32",
+  },
   SDL_RenderLogicalToWindow: {
     parameters: [
       /* SDL_Renderer* renderer */ "pointer",

--- a/src/SDL/functions.ts
+++ b/src/SDL/functions.ts
@@ -1200,6 +1200,19 @@ export function RenderGetWindow(
 }
 RenderGetWindow.symbolName = "SDL_RenderGetWindow";
 
+export function RenderSetLogicalSize(
+  renderer: PointerLike<Renderer>,
+  width: i32,
+  height: i32,
+): i32 {
+  return _library.symbols.SDL_RenderSetLogicalSize(
+    Platform.toPlatformPointer(Pointer.of(renderer)),
+    width,
+    height,
+  ) as i32;
+}
+RenderSetLogicalSize.symbolName = "SDL_RenderSetLogicalSize";
+
 export function RenderLogicalToWindow(
   renderer: PointerLike<Renderer>,
   logicalX: f32,

--- a/tools/codegen/SDL/functions.ts
+++ b/tools/codegen/SDL/functions.ts
@@ -1426,6 +1426,22 @@ export const functions: CodeGenFunctions = {
       type: "SDL_Window*",
     },
   },
+  SDL_RenderSetLogicalSize: {
+    parameters: {
+      renderer: {
+        type: "SDL_Renderer*",
+      },
+      width: {
+        type: "int",
+      },
+      height: {
+        type: "int",
+      },
+    },
+    result: {
+      type: "int"
+    }
+  },
   SDL_RenderLogicalToWindow: {
     parameters: {
       renderer: {


### PR DESCRIPTION
To allow resolution independent rendering, this PR adds support for `SDL_RenderSetLogicalSize`.

The renderer example has been updated to work with this new method and added the `RESIZABLE` window flag to be able to resize the window and visualize it's effects.