### PR TITLE
Add SDL.SetRenderTarget binding

### DIFF
--- a/src/SDL/_symbols.ts
+++ b/src/SDL/_symbols.ts
@@ -775,6 +775,13 @@ export const symbols = {
     ],
     result: /* int */ "i32",
   },
+  SDL_SetRenderTarget: {
+    parameters: [
+      /* SDL_Renderer* renderer */ "pointer",
+      /* SDL_Texture* texture */ "pointer",
+    ],
+    result: /* int */ "i32",
+  },
   SDL_SetSurfaceBlendMode: {
     parameters: [
       /* SDL_Surface* surface */ "pointer",

--- a/src/SDL/functions.ts
+++ b/src/SDL/functions.ts
@@ -1502,6 +1502,21 @@ export function SetRenderDrawColor(
 }
 SetRenderDrawColor.symbolName = "SDL_SetRenderDrawColor";
 
+export function SetRenderTarget(
+  renderer: Pointer<Renderer>,
+  texture: Pointer<Texture> | null,
+): int {
+  const _result = _library.symbols.SDL_SetRenderTarget(
+    Platform.toPlatformPointer(renderer),
+    texture ? Platform.toPlatformPointer(texture) : null,
+  ) as int;
+  if (_result < 0) {
+    throw new SDLError(GetError());
+  }
+  return _result;
+}
+SetRenderTarget.symbolName = "SDL_SetRenderTarget";
+
 export function SetSurfaceBlendMode(
   surface: PointerLike<Surface>,
   blendMode: BlendMode,

--- a/src/SDL/functions.ts
+++ b/src/SDL/functions.ts
@@ -1508,7 +1508,7 @@ export function SetRenderTarget(
 ): int {
   const _result = _library.symbols.SDL_SetRenderTarget(
     Platform.toPlatformPointer(renderer),
-    texture ? Platform.toPlatformPointer(texture) : null,
+    Platform.toPlatformPointer(texture),
   ) as int;
   if (_result < 0) {
     throw new SDLError(GetError());

--- a/tools/codegen/SDL/functions.ts
+++ b/tools/codegen/SDL/functions.ts
@@ -1603,6 +1603,20 @@ export const functions: CodeGenFunctions = {
     },
     checkForError: true,
   },
+  SDL_SetRenderTarget: {
+    parameters: {
+      renderer: {
+        type: "SDL_Renderer*",
+      },
+      texture: {
+        type: "SDL_Texture*",
+      },
+    },
+    result: {
+      type: "int",
+    },
+    checkForError: true,
+  },
   SDL_SetSurfaceBlendMode: {
     parameters: {
       surface: {

--- a/tools/codegen/SDL/functions.ts
+++ b/tools/codegen/SDL/functions.ts
@@ -1610,6 +1610,7 @@ export const functions: CodeGenFunctions = {
       },
       texture: {
         type: "SDL_Texture*",
+        isNullable: true
       },
     },
     result: {


### PR DESCRIPTION
Usage

```ts
const width = 100
const height = 100

const texture = SDL.CreateTexture(
  renderer,
  SDL.PIXELFORMAT_RGBA8888,
  SDL.TextureAccess.TARGET,
  width,
  height,
);

// takes Pointer<Texture> or null for texture
SDL.SetRenderTarget(renderer, texture);

// draw to texture
SDL.SetRenderDrawColor(renderer, 255, 0, 0, 255);
SDL.RenderFillRect(
  renderer,
  new SDL.Rect({
    x: 0,
    y: 0,
    w: width,
    h: height,
  }),
);

// set target back to renderer
SDL.SetRenderTarget(renderer, null);

// draw texture to renderer
SDL.RenderCopy(
  renderer,
  texture,
  null,
  new SDL.Rect({
    x: 0,
    y: 0,
    w: width,
    h: height,
  }),
);
```